### PR TITLE
Add graph support as input for the UI

### DIFF
--- a/src/hamilbus/main.py
+++ b/src/hamilbus/main.py
@@ -10,14 +10,15 @@ def main() -> None:
     DATA_DIR = Path(__file__).resolve().parents[1] / "hamilbus" / "data"
     STOPS_PATH = DATA_DIR / "stops.txt"
     ROUTES_PATH = DATA_DIR / "routes.txt"
-    SHAPES_PATH = DATA_DIR / "shapes.txt"
+    TRIPS_PATH = DATA_DIR / "trips.txt"
+    STOP_TIMES_PATH = DATA_DIR / "stop_times.txt"
     stops = reader.load_stops(STOPS_PATH)
-    lines = reader.load_lines(ROUTES_PATH, SHAPES_PATH)
+    lines = reader.load_lines(ROUTES_PATH)
+    trips_by_lines = reader.load_trips_per_line(TRIPS_PATH)
+    stops_by_trips = reader.load_stops_per_trip(STOP_TIMES_PATH)
 
-    graph_builder = GraphBuilder(stops, lines)
-    graph_builder.assign_stops_to_lines()
+    graph_builder = GraphBuilder(stops, lines, trips_by_lines, stops_by_trips)
     graph_builder.merge_stops()
-    graph_builder.order_stops()
     graph = graph_builder.build_graph()
 
     set_graph_network(graph)

--- a/src/hamilbus/main.py
+++ b/src/hamilbus/main.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import hamilbus.reader as reader
 from hamilbus.graph_builder import GraphBuilder
-from hamilbus.web import run_server, set_network, set_graph
+from hamilbus.web import run_server, set_graph
 
 
 def main() -> None:

--- a/src/hamilbus/main.py
+++ b/src/hamilbus/main.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import hamilbus.reader as reader
 from hamilbus.graph_builder import GraphBuilder
-from hamilbus.web import run_server, set_network
+from hamilbus.web import run_server, set_network, set_graph
 
 
 def main() -> None:
@@ -18,9 +18,9 @@ def main() -> None:
     graph_builder.assign_stops_to_lines()
     graph_builder.merge_stops()
     graph_builder.order_stops()
+    graph = graph_builder.build_graph()
 
-    set_network(stops, lines)
-
+    set_graph(graph)
     run_server(host="127.0.0.1", port=3000)
 
 

--- a/src/hamilbus/main.py
+++ b/src/hamilbus/main.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import hamilbus.reader as reader
 from hamilbus.graph_builder import GraphBuilder
-from hamilbus.web import run_server, set_graph
+from hamilbus.web import run_server, set_graph_network
 
 
 def main() -> None:
@@ -20,7 +20,7 @@ def main() -> None:
     graph_builder.order_stops()
     graph = graph_builder.build_graph()
 
-    set_graph(graph)
+    set_graph_network(graph)
     run_server(host="127.0.0.1", port=3000)
 
 

--- a/src/hamilbus/web/__init__.py
+++ b/src/hamilbus/web/__init__.py
@@ -1,4 +1,4 @@
 from .server import run_server
-from .app import set_network, set_graph
+from .app import set_network, set_graph_network
 
-__all__ = ["run_server", "set_network", "set_graph"]
+__all__ = ["run_server", "set_network", "set_graph_network"]

--- a/src/hamilbus/web/__init__.py
+++ b/src/hamilbus/web/__init__.py
@@ -1,4 +1,4 @@
 from .server import run_server
-from .app import set_network
+from .app import set_network, set_graph
 
-__all__ = ["run_server", "set_network"]
+__all__ = ["run_server", "set_network", "set_graph"]

--- a/src/hamilbus/web/app.py
+++ b/src/hamilbus/web/app.py
@@ -12,7 +12,7 @@ _STATIC_DIR = Path(__file__).parent / "static"
 
 app = FastAPI(title="Hamilbus Local Viewer")
 app.mount("/static", StaticFiles(directory=_STATIC_DIR), name="static")
-_network: tuple | None = None  # (stops, lines)
+_network: tuple[Stop, Line] | None = None  # (stops, lines)
 _graph = None  # BusNetworkGraph
 
 

--- a/src/hamilbus/web/app.py
+++ b/src/hamilbus/web/app.py
@@ -6,30 +6,43 @@ from fastapi import FastAPI
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
-from .serializers import line_payload, stop_payload
+from .serializers import line_payload, stop_payload, graph_lines_payload
 
 _STATIC_DIR = Path(__file__).parent / "static"
 
 app = FastAPI(title="Hamilbus Local Viewer")
 app.mount("/static", StaticFiles(directory=_STATIC_DIR), name="static")
-_network: tuple | None = None
-
+_network: tuple | None = None # (stops, lines)
+_graph = None # BusNetworkGraph
 
 def set_network(stops, lines):
-    global _network
+    global _network, _graph
     _network = (stops, lines)
+    _graph = None
+
+def set_graph(bus_network_graph):
+    global _network, _graph
+    _graph = bus_network_graph
+    _network = None
 
 
 @app.get("/api/stops")
 def api_stops() -> JSONResponse:
-    stops, _ = _network
+    if _graph is not None:
+        stops = _graph.get_stops()
+    else :
+        stops, _ = _network
     return JSONResponse([stop_payload(stop) for stop in stops])
 
 
 @app.get("/api/lines")
 def api_lines() -> JSONResponse:
-    _, lines = _network
-    return JSONResponse([line_payload(line) for line in lines])
+    if _graph is not None:
+        edges = _graph.get_edges() # list[tuple[Stop, Stop, dict]]
+        return JSONResponse(graph_lines_payload(edges))
+    else :
+        _, lines = _network
+        return JSONResponse([line_payload(line) for line in lines])
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/src/hamilbus/web/app.py
+++ b/src/hamilbus/web/app.py
@@ -8,12 +8,14 @@ from fastapi.staticfiles import StaticFiles
 
 from .serializers import line_payload, stop_payload, graph_lines_payload
 
+from hamilbus.datamodels import Stop, Line, BusNetworkGraph
+
 _STATIC_DIR = Path(__file__).parent / "static"
 
 app = FastAPI(title="Hamilbus Local Viewer")
 app.mount("/static", StaticFiles(directory=_STATIC_DIR), name="static")
 _network: tuple[Stop, Line] | None = None  # (stops, lines)
-_graph = None  # BusNetworkGraph
+_graph: BusNetworkGraph | None = None  # BusNetworkGraph
 
 
 def set_network(stops, lines):
@@ -22,7 +24,7 @@ def set_network(stops, lines):
     _graph = None
 
 
-def set_graph(bus_network_graph):
+def set_graph_network(bus_network_graph):
     global _network, _graph
     _graph = bus_network_graph
     _network = None

--- a/src/hamilbus/web/app.py
+++ b/src/hamilbus/web/app.py
@@ -12,13 +12,15 @@ _STATIC_DIR = Path(__file__).parent / "static"
 
 app = FastAPI(title="Hamilbus Local Viewer")
 app.mount("/static", StaticFiles(directory=_STATIC_DIR), name="static")
-_network: tuple | None = None # (stops, lines)
-_graph = None # BusNetworkGraph
+_network: tuple | None = None  # (stops, lines)
+_graph = None  # BusNetworkGraph
+
 
 def set_network(stops, lines):
     global _network, _graph
     _network = (stops, lines)
     _graph = None
+
 
 def set_graph(bus_network_graph):
     global _network, _graph
@@ -30,7 +32,7 @@ def set_graph(bus_network_graph):
 def api_stops() -> JSONResponse:
     if _graph is not None:
         stops = _graph.get_stops()
-    else :
+    else:
         stops, _ = _network
     return JSONResponse([stop_payload(stop) for stop in stops])
 
@@ -38,9 +40,9 @@ def api_stops() -> JSONResponse:
 @app.get("/api/lines")
 def api_lines() -> JSONResponse:
     if _graph is not None:
-        edges = _graph.get_edges() # list[tuple[Stop, Stop, dict]]
+        edges = _graph.get_edges()  # list[tuple[Stop, Stop, dict]]
         return JSONResponse(graph_lines_payload(edges))
-    else :
+    else:
         _, lines = _network
         return JSONResponse([line_payload(line) for line in lines])
 

--- a/src/hamilbus/web/serializers.py
+++ b/src/hamilbus/web/serializers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Any
-from itertools import groupby
 
 from ..datamodels import Line, Stop
 

--- a/src/hamilbus/web/serializers.py
+++ b/src/hamilbus/web/serializers.py
@@ -7,26 +7,24 @@ from ..datamodels import Line, Stop
 
 def stop_payload(stop: Stop) -> dict[str, Any]:
     return {
-        "index": stop.index,
+        "id": stop.id,
         "name": stop.name,
         "type": stop.type,
         "lat": stop.lat,
         "lon": stop.lon,
-        "lines": [line.index for line in stop.lines],
-        "parent_station_idx": stop.parent_station_idx,
+        "lines": [line.id for line in stop.lines],
+        "parent_station_id": stop.parent_station_id,
     }
 
 
 def line_payload(line: Line) -> dict[str, Any]:
-    if line.shape:
-        shape = [{"lat": lat, "lon": lon} for lat, lon in line.shape]
-    elif line.stops:
+    if line.stops:
         shape = [{"lat": stop.lat, "lon": stop.lon} for stop in line.stops]
     else:
         shape = []
 
     return {
-        "index": line.index,
+        "id": line.id,
         "name": line.name,
         "long_name": line.long_name,
         "color": line.color or "#3388ff",
@@ -36,14 +34,14 @@ def line_payload(line: Line) -> dict[str, Any]:
 
 def graph_lines_payload(edges: list[tuple]) -> list[dict[str, Any]]:
     """Group edges by line and return one entry per line with multiple segments."""
-    # Group by line index (fall back to line name if index missing)
+    # Group by line id (fall back to line name if id missing)
     grouped: dict[Any, dict] = {}
     for stop1, stop2, data in edges:
         line = data.get("line")
-        key = line.index if line else -1
+        key = line.id if line else -1
         if key not in grouped:
             grouped[key] = {
-                "index": key,
+                "id": key,
                 "name": line.name if line else "Edge",
                 "long_name": line.long_name if line else "",
                 "color": (line.color if line and line.color else None) or "#3388ff",

--- a/src/hamilbus/web/serializers.py
+++ b/src/hamilbus/web/serializers.py
@@ -33,6 +33,7 @@ def line_payload(line: Line) -> dict[str, Any]:
         "shape": shape,
     }
 
+
 def graph_lines_payload(edges: list[tuple]) -> list[dict[str, Any]]:
     """Group edges by line and return one entry per line with multiple segments."""
     # Group by line index (fall back to line name if index missing)
@@ -48,8 +49,10 @@ def graph_lines_payload(edges: list[tuple]) -> list[dict[str, Any]]:
                 "color": (line.color if line and line.color else None) or "#3388ff",
                 "segments": [],
             }
-        grouped[key]["segments"].append([
-            {"lat": stop1.lat, "lon": stop1.lon},
-            {"lat": stop2.lat, "lon": stop2.lon},
-        ])
+        grouped[key]["segments"].append(
+            [
+                {"lat": stop1.lat, "lon": stop1.lon},
+                {"lat": stop2.lat, "lon": stop2.lon},
+            ]
+        )
     return list(grouped.values())

--- a/src/hamilbus/web/serializers.py
+++ b/src/hamilbus/web/serializers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from itertools import groupby
 
 from ..datamodels import Line, Stop
 
@@ -32,3 +33,24 @@ def line_payload(line: Line) -> dict[str, Any]:
         "color": line.color or "#3388ff",
         "shape": shape,
     }
+
+def graph_lines_payload(edges: list[tuple]) -> list[dict[str, Any]]:
+    """Group edges by line and return one entry per line with multiple segments."""
+    # Group by line index (fall back to line name if index missing)
+    grouped: dict[Any, dict] = {}
+    for stop1, stop2, data in edges:
+        line = data.get("line")
+        key = line.index if line else -1
+        if key not in grouped:
+            grouped[key] = {
+                "index": key,
+                "name": line.name if line else "Edge",
+                "long_name": line.long_name if line else "",
+                "color": (line.color if line and line.color else None) or "#3388ff",
+                "segments": [],
+            }
+        grouped[key]["segments"].append([
+            {"lat": stop1.lat, "lon": stop1.lon},
+            {"lat": stop2.lat, "lon": stop2.lon},
+        ])
+    return list(grouped.values())

--- a/src/hamilbus/web/static/index.html
+++ b/src/hamilbus/web/static/index.html
@@ -130,7 +130,7 @@ body{font-family:Arial,Helvetica,sans-serif;height:100vh;overflow:hidden;backgro
           return L.polyline(seg.map(function(p) { return [p.lat, p.lon]; }),
               { color: color, weight: 2.5, opacity: 0.85 }).addTo(map);
       });
-      lineLayers[line.index] = layers;
+      lineLayers[line.id] = layers;
 
       var wrap = document.createElement("div");
       wrap.className = "line-item";

--- a/src/hamilbus/web/static/index.html
+++ b/src/hamilbus/web/static/index.html
@@ -115,12 +115,22 @@ body{font-family:Arial,Helvetica,sans-serif;height:100vh;overflow:hidden;backgro
   function drawLines(lines) {
     lineList.innerHTML = "";
     lineItems.length = 0;
+    lines.sort(function(a, b) {
+        return (a.name || "").localeCompare(b.name || "", undefined, { numeric: true, sensitivity: "base" });
+    });
     lines.forEach(function(line) {
-      if (!line.shape || line.shape.length < 2) return;
-      var coords = line.shape.map(function(p) { return [p.lat, p.lon]; });
+      var hasShape = line.shape && line.shape.length >= 2;
+      var hasSegments = line.segments && line.segments.length > 0;
+      if (!hasShape && !hasSegments) return;
       var color = line.color || "#3388ff";
-      var layer = L.polyline(coords, { color: color, weight: 2.5, opacity: 0.85 }).addTo(map);
-      lineLayers[line.index] = layer;
+      var segments = line.segments
+          ? line.segments
+          : (line.shape && line.shape.length >= 2 ? [line.shape] : []);
+      var layers = segments.map(function(seg) {
+          return L.polyline(seg.map(function(p) { return [p.lat, p.lon]; }),
+              { color: color, weight: 2.5, opacity: 0.85 }).addTo(map);
+      });
+      lineLayers[line.index] = layers;
 
       var wrap = document.createElement("div");
       wrap.className = "line-item";
@@ -129,7 +139,7 @@ body{font-family:Arial,Helvetica,sans-serif;height:100vh;overflow:hidden;backgro
       cb.type = "checkbox";
       cb.checked = true;
       cb.addEventListener("change", function() {
-        cb.checked ? layer.addTo(map) : map.removeLayer(layer);
+          layers.forEach(function(l) { cb.checked ? l.addTo(map) : map.removeLayer(l); });
       });
 
       var dot = document.createElement("span");
@@ -151,7 +161,7 @@ body{font-family:Arial,Helvetica,sans-serif;height:100vh;overflow:hidden;backgro
       wrap.appendChild(long);
       lineList.appendChild(wrap);
 
-      lineItems.push({ el: wrap, cb: cb, layer: layer, name: (line.name || "") + " " + (line.long_name || "") });
+      lineItems.push({ el: wrap, cb: cb, layers: layers, name: (line.name || "") + " " + (line.long_name || "") });
     });
     lineCountEl.textContent = lineItems.length;
   }
@@ -168,11 +178,17 @@ body{font-family:Arial,Helvetica,sans-serif;height:100vh;overflow:hidden;backgro
   });
 
   document.getElementById("btn-all").addEventListener("click", function() {
-    lineItems.forEach(function(item) { item.cb.checked = true; item.layer.addTo(map); });
+      lineItems.forEach(function(item) {
+          item.cb.checked = true;
+          item.layers.forEach(function(l) { l.addTo(map); });
+      });
   });
 
   document.getElementById("btn-none").addEventListener("click", function() {
-    lineItems.forEach(function(item) { item.cb.checked = false; map.removeLayer(item.layer); });
+      lineItems.forEach(function(item) {
+          item.cb.checked = false;
+          item.layers.forEach(function(l) { map.removeLayer(l); });
+      });
   });
 
   document.getElementById("search-input").addEventListener("input", function(e) {

--- a/src/hamilbus/web/static/index.html
+++ b/src/hamilbus/web/static/index.html
@@ -116,7 +116,12 @@ body{font-family:Arial,Helvetica,sans-serif;height:100vh;overflow:hidden;backgro
     lineList.innerHTML = "";
     lineItems.length = 0;
     lines.sort(function(a, b) {
-        return (a.name || "").localeCompare(b.name || "", undefined, { numeric: true, sensitivity: "base" });
+    var na = parseFloat(a.name);
+    var nb = parseFloat(b.name);
+    if (!isNaN(na) && !isNaN(nb)) return na - nb;   // both numeric: compare as numbers
+    if (!isNaN(na)) return -1;                        // numbers before letters
+    if (!isNaN(nb)) return 1;
+    return (a.name || "").localeCompare(b.name || ""); // both non-numeric: alphabetic
     });
     lines.forEach(function(line) {
       var hasShape = line.shape && line.shape.length >= 2;

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,37 @@
+import json
+from hamilbus.datamodels import Stop, Line
+from hamilbus.graph_builder import GraphBuilder
+from hamilbus.web.app import api_stops, api_lines, set_network, set_graph_network
+
+
+def test_serializers():
+    stops = [
+        Stop(index=0, name="Stop 1", type="parent_station", lat=40.7128, lon=-1.5006),
+        Stop(index=1, name="Stop 2", type="parent_station", lat=40.7129, lon=-1.5007),
+        Stop(index=2, name="Stop 3", type="substation", lat=40.7130, lon=-1.5008),
+        Stop(index=3, name="Stop 4", type="substation", lat=40.7131, lon=-1.5009),
+        Stop(index=4, name="Stop 5", type="substation", lat=52, lon=-12),
+    ]
+    lines = [
+        Line(index=0, name="Line 1", long_name="Line 1 Long Name", color="red", stops=[stops[0], stops[1]]),
+        Line(index=1, name="Line 2", long_name="Line 2 Long Name", color="blue", stops=[stops[0], stops[2]]),
+        Line(index=2, name="Line 3", long_name="Line 3 Long Name", color="green", stops=[stops[2], stops[3]]),
+        Line(index=3, name="Line 4", long_name="Line 4 Long Name", color="yellow", stops=[stops[1], stops[2], stops[3]]),
+    ]
+
+    set_network(stops, lines)
+    stops_json_response_network = api_stops()
+    lines_json_response_network = api_lines()
+
+    graph_builder = GraphBuilder(stops, lines)
+    graph = graph_builder.build_graph()
+
+    set_graph_network(graph)
+    stops_json_response_graph = api_stops()
+    lines_json_response_graph = api_lines()
+
+    assert stops_json_response_network.status_code == stops_json_response_graph.status_code
+    # assert json.loads(stops_json_response_network.body) == json.loads(stops_json_response_graph.body)
+
+    assert lines_json_response_network.status_code == lines_json_response_graph.status_code
+    # assert json.loads(lines_json_response_network.body) == json.loads(lines_json_response_graph.body)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -6,32 +6,45 @@ from hamilbus.web.app import api_stops, api_lines, set_network, set_graph_networ
 
 def test_serializers():
     stops = [
-        Stop(index=0, name="Stop 1", type="parent_station", lat=40.7128, lon=-1.5006),
-        Stop(index=1, name="Stop 2", type="parent_station", lat=40.7129, lon=-1.5007),
-        Stop(index=2, name="Stop 3", type="substation", lat=40.7130, lon=-1.5008),
-        Stop(index=3, name="Stop 4", type="substation", lat=40.7131, lon=-1.5009),
-        Stop(index=4, name="Stop 5", type="substation", lat=52, lon=-12),
+        Stop(id="0", name="Stop 1", type="parent_station", lat=40.7128, lon=-1.5006),
+        Stop(id="1", name="Stop 2", type="parent_station", lat=40.7129, lon=-1.5007),
+        Stop(id="2", name="Stop 3", type="substation", lat=40.7130, lon=-1.5008),
+        Stop(id="3", name="Stop 4", type="substation", lat=40.7131, lon=-1.5009),
     ]
     lines = [
-        Line(index=0, name="Line 1", long_name="Line 1 Long Name", color="red", stops=[stops[0], stops[1]]),
-        Line(index=1, name="Line 2", long_name="Line 2 Long Name", color="blue", stops=[stops[0], stops[2]]),
-        Line(index=2, name="Line 3", long_name="Line 3 Long Name", color="green", stops=[stops[2], stops[3]]),
-        Line(index=3, name="Line 4", long_name="Line 4 Long Name", color="yellow", stops=[stops[1], stops[2], stops[3]]),
+        Line(id="0", name="Line 1", long_name="Line 1 Long Name", color="red"),
+        Line(id="1", name="Line 2", long_name="Line 2 Long Name", color="blue"),
+        Line(id="2", name="Line 3", long_name="Line 3 Long Name", color="green"),
+        Line(id="3", name="Line 4", long_name="Line 4 Long Name", color="yellow"),
     ]
+    trips_by_lines = {
+        "0": ["trip0"],
+        "1": ["trip1"],
+        "2": ["trip2"],
+        "3": ["trip3"],
+    }
+    stops_by_trips = {
+        "trip0": ["0", "1"],
+        "trip1": ["0", "2"],
+        "trip2": ["2", "3"],
+        "trip3": ["1", "2", "3"],
+    }
 
+    graph_builder = GraphBuilder(stops, lines, trips_by_lines, stops_by_trips)
+    graph = graph_builder.build_graph()
+
+    # Network mode
     set_network(stops, lines)
     stops_json_response_network = api_stops()
     lines_json_response_network = api_lines()
 
-    graph_builder = GraphBuilder(stops, lines)
-    graph = graph_builder.build_graph()
-
+    # Graph mode
     set_graph_network(graph)
     stops_json_response_graph = api_stops()
     lines_json_response_graph = api_lines()
 
     assert stops_json_response_network.status_code == stops_json_response_graph.status_code
-    # assert json.loads(stops_json_response_network.body) == json.loads(stops_json_response_graph.body)
+    assert json.loads(stops_json_response_network.body) == json.loads(stops_json_response_graph.body)
 
     assert lines_json_response_network.status_code == lines_json_response_graph.status_code
-    # assert json.loads(lines_json_response_network.body) == json.loads(lines_json_response_graph.body)
+    assert len(json.loads(lines_json_response_network.body)) == len(json.loads(lines_json_response_graph.body))


### PR DESCRIPTION
Add graph support for the UI : 
- new method _set_graph that can replace or complement _set_network
- new serializer function to create a payload for edges, represented as segments of lines
- adaptation of the html

Fixes #27 

NB : run as is, the graph will look bad/not even work because of several problems and bugs I discovered in reader.py and graph_builder.py (sorting of shape points, merge_stops not assigning its result to self.stops, order_stops not working at all because of a line/line_index confusion). Since these will all be deprecated with PR #28, I didn't fix them here, but made sure that the graph was displaying correctly when fixing them locally.

@Polemique 