### PR TITLE
Refactor/bus graph network

### DIFF
--- a/src/hamilbus/datamodels.py
+++ b/src/hamilbus/datamodels.py
@@ -30,6 +30,7 @@ class Line:
 @dataclass
 class BusNetworkGraph(nx.MultiGraph):
     """Represents a graph composed of stops connected by edges."""
+
     def __init__(self):
         super().__init__()
 
@@ -54,7 +55,7 @@ class BusNetworkGraph(nx.MultiGraph):
             self.link_stops(line.stops[i], line.stops[i + 1], line)
 
     def get_stops(self) -> List[Stop]:
-        """Returns a list of all stops in the graph."""
+        """Returns a list of all stops in the graph as Stop objects."""
         return [data["stop"] for _, data in self.nodes(data=True)]
 
     def get_edges(self) -> List[tuple[Stop, Stop, dict]]:
@@ -82,5 +83,4 @@ class BusNetworkGraph(nx.MultiGraph):
                         color="gray",
                     )
                     fully_connected.add_edge(stop_u.id, stop_v.id, line=line)
-
         return fully_connected

--- a/src/hamilbus/datamodels.py
+++ b/src/hamilbus/datamodels.py
@@ -28,18 +28,18 @@ class Line:
 
 
 @dataclass
-class BusNetworkGraph:
+class BusNetworkGraph(nx.MultiGraph):
     """Represents a graph composed of stops connected by edges."""
-
-    graph: nx.MultiGraph = field(default_factory=nx.MultiGraph)
+    def __init__(self):
+        super().__init__()
 
     def add_stop(self, stop: Stop):
         """Adds a stop to the graph."""
-        self.graph.add_node(stop.id, stop=stop)
+        self.add_node(stop.id, stop=stop)
 
-    def add_edge(self, stop1: Stop, stop2: Stop, line: Line):
+    def link_stops(self, stop1: Stop, stop2: Stop, line: Line):
         """Adds an edge between two stops, with the line as an attribute."""
-        self.graph.add_edge(
+        self.add_edge(
             stop1.id,
             stop2.id,
             line=line,
@@ -51,21 +51,18 @@ class BusNetworkGraph:
         for stop in line.stops:
             self.add_stop(stop)
         for i in range(len(line.stops) - 1):
-            self.add_edge(line.stops[i], line.stops[i + 1], line)
+            self.link_stops(line.stops[i], line.stops[i + 1], line)
 
     def get_stops(self) -> List[Stop]:
         """Returns a list of all stops in the graph."""
-        return [data["stop"] for _, data in self.graph.nodes(data=True)]
+        return [data["stop"] for _, data in self.nodes(data=True)]
 
     def get_edges(self) -> List[tuple[Stop, Stop, dict]]:
         """Returns a list of all edges in the graph, with their attributes."""
         return [
-            (self.graph.nodes[u]["stop"], self.graph.nodes[v]["stop"], data)
-            for u, v, data in self.graph.edges(data=True)
+            (self.nodes[u]["stop"], self.nodes[v]["stop"], data)
+            for u, v, data in self.edges(data=True)
         ]
-
-    def has_edge(self, u, v) -> bool:
-        return self.graph.has_edge(u, v)
 
     def fully_connected_graph(self) -> nx.Graph:
         """Returns a fully connected graph where each edge weight is the shortest distance between stops."""
@@ -76,8 +73,8 @@ class BusNetworkGraph:
         for u in fully_connected.nodes:
             for v in fully_connected.nodes:
                 if u != v and not fully_connected.has_edge(u, v):
-                    stop_u = self.graph.nodes[u]["stop"]
-                    stop_v = self.graph.nodes[v]["stop"]
+                    stop_u = self.nodes[u]["stop"]
+                    stop_v = self.nodes[v]["stop"]
                     line = Line(
                         id="-1",
                         name="Direct Connection",

--- a/src/hamilbus/distance_matrix.py
+++ b/src/hamilbus/distance_matrix.py
@@ -13,9 +13,9 @@ def compute_distance_matrix(
     """Computes the shortest distance and path between all pairs of stops in the graph."""
 
     stops_index_to_id = {
-        idx: stop_id for idx, stop_id in enumerate(bus_graph.graph.nodes)
+        idx: stop_id for idx, stop_id in enumerate(bus_graph.nodes)
     }
-    len_stops = len(bus_graph.graph.nodes)
+    len_stops = len(bus_graph.nodes)
     distance_matrix = np.zeros((len_stops, len_stops))
     path_matrix = np.empty((len_stops, len_stops), dtype=object)
     strategy_func = {
@@ -30,7 +30,7 @@ def compute_distance_matrix(
             if u_idx != v_idx:
                 try:
                     length, path = strategy_func[strategy](
-                        bus_graph.graph,
+                        bus_graph,
                         stops_index_to_id[u_idx],
                         stops_index_to_id[v_idx],
                         weight="distance",

--- a/src/hamilbus/distance_matrix.py
+++ b/src/hamilbus/distance_matrix.py
@@ -12,9 +12,7 @@ def compute_distance_matrix(
 ) -> tuple[np.ndarray, np.ndarray, dict]:
     """Computes the shortest distance and path between all pairs of stops in the graph."""
 
-    stops_index_to_id = {
-        idx: stop_id for idx, stop_id in enumerate(bus_graph.nodes)
-    }
+    stops_index_to_id = {idx: stop_id for idx, stop_id in enumerate(bus_graph.nodes)}
     len_stops = len(bus_graph.nodes)
     distance_matrix = np.zeros((len_stops, len_stops))
     path_matrix = np.empty((len_stops, len_stops), dtype=object)

--- a/src/hamilbus/graph_builder.py
+++ b/src/hamilbus/graph_builder.py
@@ -115,5 +115,5 @@ class GraphBuilder:
                     graph.add_stop(stop1)
                     graph.add_stop(stop2)
                     if not graph.has_edge(stop1.id, stop2.id):
-                        graph.add_edge(stop1, stop2, line)
+                        graph.link_stops(stop1, stop2, line)
         return graph

--- a/tests/test_datamodels.py
+++ b/tests/test_datamodels.py
@@ -71,7 +71,7 @@ def test_line_creation_failure():
 # BusNetworkGraph
 def test_bus_network_graph_creation():
     graph = hbus.BusNetworkGraph()
-    assert isinstance(graph.graph, nx.MultiGraph)
+    assert isinstance(graph, nx.MultiGraph)
 
 
 def test_add_stop_to_graph():
@@ -84,8 +84,8 @@ def test_add_stop_to_graph():
         lon=-74.0060,
     )
     graph.add_stop(stop)
-    assert graph.graph.has_node(stop.id)
-    assert graph.graph.nodes[stop.id]["stop"] == stop
+    assert graph.has_node(stop.id)
+    assert graph.nodes[stop.id]["stop"] == stop
 
 
 def test_add_edge_to_graph():
@@ -106,13 +106,13 @@ def test_add_edge_to_graph():
     )
     graph.add_stop(stop1)
     graph.add_stop(stop2)
-    graph.add_edge(
+    graph.link_stops(
         stop1,
         stop2,
         line=hbus.Line(id="0", name="Line 1", long_name="Line 1 Long Name", color="red"),
     )
-    assert graph.graph.has_edge(stop1.id, stop2.id)
-    assert graph.graph[stop1.id][stop2.id][0]["line"].id == "0"
+    assert graph.has_edge(stop1.id, stop2.id)
+    assert graph[stop1.id][stop2.id][0]["line"].id == "0"
 
 
 def test_get_stops_returns_all_stops():
@@ -136,7 +136,7 @@ def test_get_edges_returns_edge_attributes():
 
     graph.add_stop(stop1)
     graph.add_stop(stop2)
-    graph.add_edge(stop1, stop2, line=line)
+    graph.link_stops(stop1, stop2, line=line)
 
     edges = graph.get_edges()
     assert len(edges) == 1
@@ -162,12 +162,12 @@ def test_add_line_connects_stops_and_adds_nodes():
 
     graph.add_line(line)
 
-    assert graph.graph.has_node("0")
-    assert graph.graph.has_node("1")
-    assert graph.graph.has_node("2")
-    assert graph.graph.number_of_edges() == 2
-    assert graph.graph["0"]["1"][0]["line"] == line
-    assert graph.graph["1"]["2"][0]["line"] == line
+    assert graph.has_node("0")
+    assert graph.has_node("1")
+    assert graph.has_node("2")
+    assert graph.number_of_edges() == 2
+    assert graph["0"]["1"][0]["line"] == line
+    assert graph["1"]["2"][0]["line"] == line
 
 
 def test_fully_connected_graph_preserves_edge_data():


### PR DESCRIPTION
Refactored the BusNetworkGraph class : 
- instead of being a data class that holds an nx.MultiGraph, it is now a class that inherits from nx.Multigraph
- This means we can directly use graph_instance.nodes, graph_instance.edges, graph_instance.has_edge... that are built-in instead of going graph_instance.graph.nodes
- Renamed the add_edge function to link_stops since "add_edge" is already the name of the built-in function, so that we can keep our custom handling of arguments
- Adapted the other files and tests.

Closes #35

@Polemique  

Note : we might want to refactor further and make it an nx.Graph instead of a MultiGraph in the future, since currently, we don't use mulitple edges. We could use them though. To be decided when treating issue #31 